### PR TITLE
Обновил timesheet.py

### DIFF
--- a/timesheet.py
+++ b/timesheet.py
@@ -1,51 +1,59 @@
-import requests
 import re
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
+
 import arrow
 import pandas as pd
+import requests
 
-settings_ini = 'settings.ini'
-toggl_url = 'https://www.toggl.com/api/v8/time_entries'
-tempo_url = 'https://api.tempo.io/core/3/worklogs'
-jira_pattern = r'[A-Za-z]{2,5}-\d+'
-end_time = arrow.utcnow().to('Europe/Moscow').format('YYYY-MM-DDTHH:mm:ssZZ')
+SETTINGS_FILE = 'settings.ini'
+TOGGL_URL = 'https://www.toggl.com/api/v8/time_entries'
+TEMPO_URL = 'https://api.tempo.io/core/3/worklogs'
+JIRA_REGEXP = re.compile(r'[A-Za-z]{2,5}-\d+')
+END_TIME = arrow.utcnow().to('Europe/Moscow').format('YYYY-MM-DDTHH:mm:ssZZ')
 
-config = SafeConfigParser()
-config.read(settings_ini)
+CONFIG = SafeConfigParser()
+CONFIG.read(SETTINGS_FILE)
 
-params = {'start_date': config.get('tempo', 'lastSuccessful'),
-          'end_date': end_time}
+params = {'start_date': CONFIG.get('tempo', 'lastSuccessful'), 'end_date': END_TIME}
 
-toggl_response = requests.get(toggl_url, auth=(config.get('toggl', 'token'), 'api_token'), params=params)
+toggl_response = requests.get(TOGGL_URL, auth=(CONFIG.get('toggl', 'token'), 'api_token'), params=params)
 
 df = pd.DataFrame(toggl_response.json())
 df['date'] = df.apply(lambda row: (arrow.get(row.start)).date().isoformat(), axis=1)
-grouped = df.groupby(['description', 'date']).agg({'start': 'min', 'duration': 'sum'})[
-    ['start', 'duration']].reset_index()
+grouped = df.groupby(['description', 'date']).agg({'start': 'min', 'duration': 'sum'})[['start', 'duration']].reset_index()
 collapsed_data = grouped.to_dict('r')
 
 for task in collapsed_data:
     key = ''
-    if re.search(jira_pattern, task.get('description')):
-        key = re.search(jira_pattern, task.get('description')).group()
+    if JIRA_REGEXP.search(task.get('description')):
+        key = JIRA_REGEXP.search(task.get('description')).group()
     else:
-        key = config.get('tempo', 'defaultKey')
+        key = CONFIG.get('tempo', 'defaultKey')
 
     start_date = task.get('date')
     start_time = arrow.get(task.get('start')).time().isoformat()
     description = ''
     if not description:
-        description = config.get('tempo', 'defaultDescription')
+        description = CONFIG.get('tempo', 'defaultDescription')
     else:
         description = task.get('description').replace(key, '').strip()
 
-    data = {'issueKey': key, 'timeSpentSeconds': task.get('duration'), 'startDate': start_date,
-            'startTime': start_time, 'description': description, 'authorAccountId': config.get('authorAccountId')}
+    data = {
+        'issueKey': key,
+        'timeSpentSeconds': task.get('duration'),
+        'startDate': start_date,
+        'startTime': start_time,
+        'description': description,
+        'authorAccountId': CONFIG.get('authorAccountId'),
+    }
 
-    requests.post(tempo_url, json=data, headers={'Content-Type': 'application/json',
-                                                 'Authorization': 'Bearer ' + config.get('tempo', 'token')})
+    requests.post(
+        TEMPO_URL, json=data, headers={'Content-Type': 'application/json', 'Authorization': 'Bearer ' + CONFIG.get('tempo', 'token')}
+    )
 
-config.set('tempo', 'lastSuccessful', end_time)
-with open('settings.ini', 'wb') as configfile:
-    config.write(configfile)
+CONFIG.set('tempo', 'lastSuccessful', END_TIME)
+
+    with open('settings.ini', 'wb') as file:
+    CONFIG.write(file)
+
 print('done')


### PR DESCRIPTION
+ Немного не "питонические" переносы в некоторых местах.
+ Отсортировал импортирования: (вначале идут импорты стандартной библиотеки, затем внешние библиотеки; все в алф. порядке; вначале import потом from импорты).
+ Регулярные выражения принято предварительно компилировать.
+ Типа "константы" принято писать капсом в питоне.
+ При `with open(...) as file:` принято писать file.